### PR TITLE
Add database persistence layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+## Local demo
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+pytest -q      # run unit tests
+python - <<'PY'
+from db import repository as repo
+from tools.health_schema import SymptomLog
+log = SymptomLog(symptom="headache", severity="mild", started_at="now")
+repo.add_log(log)
+print(repo.list_logs())
+PY
+```

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,4 @@
+from .engine import SessionLocal, Base  # noqa: F401
+from .repository import add_log, list_logs, get_log  # noqa: F401
+
+__all__ = ["SessionLocal", "add_log", "list_logs", "get_log", "Base"]

--- a/db/engine.py
+++ b/db/engine.py
@@ -1,0 +1,24 @@
+"""
+SQLAlchemy engine + Session factory
+"""
+from pathlib import Path
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, DeclarativeBase
+
+DB_PATH = Path(__file__).resolve().parent.parent / "health.db"
+SQLALCHEMY_DATABASE_URL = f"sqlite:///{DB_PATH}"
+
+class Base(DeclarativeBase):
+    """Declarative base for all ORM models."""
+    pass
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},  # needed for SQLite multithread
+    echo=False,
+)
+SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+# Create tables as soon as module is imported
+from db import models  # noqa: E402 – side-effect import
+Base.metadata.create_all(engine)

--- a/db/models.py
+++ b/db/models.py
@@ -1,0 +1,31 @@
+"""
+SQLAlchemy ↔️ Pydantic mapping for SymptomLog.
+"""
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Enum,
+    String,
+    Text,
+)
+from sqlalchemy.dialects.sqlite import JSON
+from uuid import uuid4
+
+from db.engine import Base
+from tools.health_schema import Severity
+
+class SymptomLogORM(Base):
+    __tablename__ = "symptom_logs"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid4()))
+    created_at = Column(DateTime(timezone=True), nullable=False, index=True)
+    symptom = Column(String, nullable=False)
+    severity = Column(Enum(Severity), nullable=False)
+    started_at = Column(DateTime(timezone=True), nullable=False)
+    ended_at = Column(DateTime(timezone=True))
+    location = Column(String)
+    medicines_taken = Column(JSON)
+    notes = Column(Text)

--- a/db/repository.py
+++ b/db/repository.py
@@ -1,0 +1,40 @@
+"""
+Thin CRUD wrapper around SQLAlchemy sessions.
+"""
+from contextlib import contextmanager
+from typing import Iterable, List
+
+from db.engine import SessionLocal
+from db.models import SymptomLogORM
+from tools.health_schema import SymptomLog
+
+@contextmanager
+def session_scope():
+    db = SessionLocal()
+    try:
+        yield db
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+# ---------- CRUD -----------------------------------------------------
+
+def add_log(log: SymptomLog) -> None:
+    """Persist a ``SymptomLog`` instance."""
+    with session_scope() as db:
+        db.add(SymptomLogORM(**log.model_dump()))
+
+def list_logs() -> List[SymptomLog]:
+    with session_scope() as db:
+        rows: Iterable[SymptomLogORM] = db.query(SymptomLogORM).all()
+        return [SymptomLog.model_validate(row, from_attributes=True) for row in rows]
+
+def get_log(log_id: str) -> SymptomLog | None:
+    with session_scope() as db:
+        row = db.get(SymptomLogORM, log_id)
+        return (
+            SymptomLog.model_validate(row, from_attributes=True) if row else None
+        )

--- a/tests/test_db_repo.py
+++ b/tests/test_db_repo.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from zoneinfo import ZoneInfo
+from db import repository as repo
+from tools.health_schema import Severity, SymptomLog, natural_language_to_datetime
+
+
+def test_repo_roundtrip(tmp_path, monkeypatch):
+    # Redirect health.db to a temp directory for isolation
+    monkeypatch.chdir(tmp_path)
+
+    # Create a sample log
+    dt = natural_language_to_datetime("2024-07-01 08:00", user_tz="America/New_York")
+    log = SymptomLog(
+        symptom="nausea",
+        severity="intense",     # synonym → severe
+        started_at=dt,
+        location="home",
+        medicines_taken=["gravol"],
+        notes="before breakfast",
+    )
+    repo.add_log(log)
+
+    logs = repo.list_logs()
+    assert len(logs) == 1
+    roundtrip = logs[0]
+
+    # severity synonym mapping
+    assert roundtrip.severity is Severity.severe
+    # TZ conversion
+    assert roundtrip.started_at.tzinfo is ZoneInfo("UTC")
+    # duration property
+    assert roundtrip.duration is None


### PR DESCRIPTION
## Summary
- implement SQLAlchemy engine and session factory
- map `SymptomLog` to SQLite via SQLAlchemy ORM
- add simple repository API for CRUD operations
- expose repo methods in `db.__init__`
- document quick-start example in README
- test persistence behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68654f2a18a0832f9a1c3fcfada32a91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a database-backed repository for managing symptom logs, including the ability to add, list, and retrieve logs.
  * Added a new ORM model for symptom logs with support for severity, timestamps, location, medicines, and notes.
  * Provided a context-managed session for safe database operations.

* **Documentation**
  * Added a "Local demo" section to the README with step-by-step instructions for setup and usage.

* **Tests**
  * Added tests to verify correct storage, retrieval, and normalization of symptom log data in the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->