### PR TITLE
Add tool_log utility

### DIFF
--- a/tools/log_entry.py
+++ b/tools/log_entry.py
@@ -4,8 +4,10 @@ from tools.health_schema import SymptomLog, Severity
 from db.engine import SessionLocal, Base, engine
 from db.models import SymptomLogORM
 
-# Ensure tables exist
-Base.metadata.create_all(engine)
+
+def ensure_tables() -> None:
+    """Create database tables if they do not already exist."""
+    Base.metadata.create_all(engine)
 
 
 def tool_log(text: str, user_id: str) -> str:
@@ -18,6 +20,8 @@ def tool_log(text: str, user_id: str) -> str:
     user_id : str
         Identifier for the submitting user.
     """
+    ensure_tables()
+
     entry = SymptomLog(
         symptom=text,
         severity=Severity.none,

--- a/tools/log_entry.py
+++ b/tools/log_entry.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+from tools.health_schema import SymptomLog, Severity
+from db.engine import SessionLocal, Base, engine
+from db.models import SymptomLogORM
+
+# Ensure tables exist
+Base.metadata.create_all(engine)
+
+
+def tool_log(text: str, user_id: str) -> str:
+    """Persist a free-form symptom description.
+
+    Parameters
+    ----------
+    text : str
+        Description provided by the user.
+    user_id : str
+        Identifier for the submitting user.
+    """
+    entry = SymptomLog(
+        symptom=text,
+        severity=Severity.none,
+        started_at=datetime.utcnow(),
+        notes=f"user:{user_id}",
+    )
+
+    with SessionLocal() as db:
+        orm_entry = SymptomLogORM(**entry.model_dump())
+        db.add(orm_entry)
+        db.commit()
+        db.refresh(orm_entry)
+
+    return f"Logged entry with id: {orm_entry.id}"

--- a/tools/log_entry.py
+++ b/tools/log_entry.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+from datetime import datetime, timezone
+import json
 
 from tools.health_schema import SymptomLog, Severity
 from db.engine import SessionLocal, Base, engine
@@ -25,8 +26,8 @@ def tool_log(text: str, user_id: str) -> str:
     entry = SymptomLog(
         symptom=text,
         severity=Severity.none,
-        started_at=datetime.utcnow(),
-        notes=f"user:{user_id}",
+        started_at=datetime.now(timezone.utc),
+        notes=json.dumps({"user_id": user_id}),
     )
 
     with SessionLocal() as db:


### PR DESCRIPTION
## Summary
- implement `tool_log` function in a new module `tools/log_entry.py`
- ensure database tables exist on import and log symptom text via SQLAlchemy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68712f4544f4832fb6b7412c07fb450c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the ability to log free-form symptom descriptions for users, with confirmation provided upon successful entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->