### PR TITLE
Add summarization tool and dynamic database engine

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,4 +1,4 @@
-from .engine import Base, get_engine  # noqa: F401
+from .engine import Base, get_engine, init_db  # noqa: F401
 from .repository import add_log, list_logs, get_log  # noqa: F401
 
-__all__ = ["add_log", "list_logs", "get_log", "Base", "get_engine"]
+__all__ = ["add_log", "list_logs", "get_log", "Base", "get_engine", "init_db"]

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,4 +1,4 @@
-from .engine import SessionLocal, Base  # noqa: F401
+from .engine import Base, get_engine  # noqa: F401
 from .repository import add_log, list_logs, get_log  # noqa: F401
 
-__all__ = ["SessionLocal", "add_log", "list_logs", "get_log", "Base"]
+__all__ = ["add_log", "list_logs", "get_log", "Base", "get_engine"]

--- a/db/repository.py
+++ b/db/repository.py
@@ -4,12 +4,19 @@ Thin CRUD wrapper around SQLAlchemy sessions.
 from contextlib import contextmanager
 from typing import Iterable, List
 
-from db.engine import SessionLocal
+from sqlalchemy.orm import sessionmaker
+
+from db.engine import Base, get_engine
 from db.models import SymptomLogORM
 from tools.health_schema import SymptomLog
 
 @contextmanager
 def session_scope():
+    """Provide a transactional scope around a series of operations."""
+
+    engine = get_engine()
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
     db = SessionLocal()
     try:
         yield db

--- a/db/repository.py
+++ b/db/repository.py
@@ -8,6 +8,11 @@ from typing import Iterable, List
 from sqlalchemy.orm import sessionmaker
 
 from db.engine import Base, get_engine, init_db
+
+# Create the engine and session factory once at import time
+_engine = get_engine()
+init_db(_engine)
+SessionLocal = sessionmaker(bind=_engine, expire_on_commit=False)
 from db.models import SymptomLogORM
 from tools.health_schema import SymptomLog
 
@@ -15,9 +20,6 @@ from tools.health_schema import SymptomLog
 def session_scope():
     """Provide a transactional scope around a series of operations."""
 
-    engine = get_engine()
-    init_db(engine)
-    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
     db = SessionLocal()
     try:
         yield db

--- a/db/repository.py
+++ b/db/repository.py
@@ -4,9 +4,10 @@ Thin CRUD wrapper around SQLAlchemy sessions.
 from contextlib import contextmanager
 from typing import Iterable, List
 
+
 from sqlalchemy.orm import sessionmaker
 
-from db.engine import Base, get_engine
+from db.engine import Base, get_engine, init_db
 from db.models import SymptomLogORM
 from tools.health_schema import SymptomLog
 
@@ -15,7 +16,7 @@ def session_scope():
     """Provide a transactional scope around a series of operations."""
 
     engine = get_engine()
-    Base.metadata.create_all(engine)
+    init_db(engine)
     SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
     db = SessionLocal()
     try:

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+# Tools package

--- a/tools/get_entries.py
+++ b/tools/get_entries.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import List
+
+from db.repository import list_logs
+from tools.health_schema import SymptomLog
+
+
+def tool_get_entries(user_id: str) -> List[SymptomLog]:
+    """Return all symptom logs for the given user.
+
+    Current implementation ignores the ``user_id`` because user handling
+    is not yet implemented. The interface remains to support future
+    multi-user storage.
+    """
+
+    # In a real application we would filter by ``user_id``.
+    return list_logs()

--- a/tools/summarize.py
+++ b/tools/summarize.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import List
+
+from llama_index import VectorStoreIndex, ServiceContext, Document
+from llama_index.llms import OpenAI
+
+from tools.get_entries import tool_get_entries
+
+
+_DEF_TEMP = 0.3
+
+
+def _to_documents(entries: List[str]) -> List[Document]:
+    docs: List[Document] = []
+    for idx, entry in enumerate(entries):
+        text = getattr(entry, "text", None) or str(entry)
+        docs.append(Document(text=text, id_=str(idx)))
+    return docs
+
+
+def tool_summarize(user_id: str) -> str:
+    """Return a doctor-friendly bullet summary of a user's recent entries."""
+
+    entries = tool_get_entries(user_id)
+    if not entries:
+        return "No entries found."
+
+    docs = _to_documents(entries[-5:])  # last N entries
+
+    service_context = ServiceContext.from_defaults(
+        llm=OpenAI(temperature=_DEF_TEMP)
+    )
+    index = VectorStoreIndex.from_documents(docs, service_context=service_context)
+    query_engine = index.as_query_engine(similarity_top_k=5)
+    response = query_engine.query(
+        "Summarize the patient's recent symptom entries in concise bullet points for a doctor."
+    )
+    return str(response).strip()


### PR DESCRIPTION
## Summary
- add dynamic engine generation using current working directory
- adjust repository session scope to create tables on demand
- update db package exports
- implement `tool_summarize` with LlamaIndex for doctor-friendly summaries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687139667ef8832fa25061e4f7e1fd17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tool to generate concise, doctor-friendly bullet summaries of a user's recent symptom entries.
* **Refactor**
  * Improved database engine creation by switching to dynamic, on-demand engine instantiation, removing fixed paths and global variables.
  * Updated session management to create sessions within context and ensure tables are created dynamically.
* **Chores**
  * Updated internal imports and exports to reflect the new database engine approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->