### PR TITLE
Add user entry retrieval tool

### DIFF
--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,8 @@
+"""Helper tools for the HealthTrack agent."""
+
+__all__ = ["tool_get_entries"]
+
+
+def tool_get_entries(*args, **kwargs):
+    from .get_entries import tool_get_entries as _impl
+    return _impl(*args, **kwargs)


### PR DESCRIPTION
## Summary
- define `tool_get_entries` helper to look up entries for a user
- expose `tool_get_entries` from the tools package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883eb643b80832f81bcbbac79c196b5