### PR TITLE
Fix session_scope to recreate engine on cwd change

### DIFF
--- a/db/repository.py
+++ b/db/repository.py
@@ -2,15 +2,49 @@
 Thin CRUD wrapper around SQLAlchemy sessions.
 """
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Iterable, List
 
-from db.engine import SessionLocal
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from db.engine import SessionLocal as _DefaultSessionLocal, engine as _default_engine, Base
 from db.models import SymptomLogORM
 from tools.health_schema import SymptomLog
 
+_engine_cwd = Path.cwd()
+_engine = _default_engine
+_SessionLocal = _DefaultSessionLocal
+
+def init_db(engine) -> None:
+    """Create database tables for a given engine."""
+    from db import models  # noqa: F401 – ensure model import for metadata
+
+    Base.metadata.create_all(engine)
+
 @contextmanager
 def session_scope():
-    db = SessionLocal()
+    """Provide a transactional scope around a series of operations.
+
+    If the current working directory changes, a new engine bound to the
+    directory's ``health.db`` is created and initialized.
+    """
+    global _engine_cwd, _engine, _SessionLocal
+
+    cwd = Path.cwd()
+    if cwd != _engine_cwd:
+        db_path = cwd / "health.db"
+        url = f"sqlite:///{db_path}"
+        _engine = create_engine(
+            url,
+            connect_args={"check_same_thread": False},
+            echo=False,
+        )
+        _SessionLocal = sessionmaker(bind=_engine, expire_on_commit=False)
+        _engine_cwd = cwd
+        init_db(_engine)
+
+    db = _SessionLocal()
     try:
         yield db
         db.commit()


### PR DESCRIPTION
## Summary
- detect working directory changes in `db.repository.session_scope`
- rebuild SQLAlchemy engine and session when cwd changes
- initialize tables on the new engine

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883eb65dde0832fbc78aeb8867a4104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database sessions now automatically adapt to the current working directory, ensuring data is stored and accessed locally within each directory.
* **Improvements**
  * Database tables are initialized automatically when switching directories, reducing manual setup.
* **Bug Fixes**
  * Prevented potential issues with database connections when changing directories during application use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->