### PR TITLE
Add upsert support for symptom index updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.db
 logs/
 *.ipynb
+storage/

--- a/memory/index.py
+++ b/memory/index.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import List
+from typing import Iterable, List
 from llama_index.core import Document, StorageContext, VectorStoreIndex, load_index_from_storage
 from llama_index.embeddings.openai import OpenAIEmbedding
 from tools.health_schema import SymptomLog
@@ -57,6 +57,13 @@ def add_entry_to_index(user_id: str, entry: SymptomLog) -> None:
     """Append a single entry to an existing (or new) user index and persist."""
     index = build_or_load_index(user_id)  # loads or builds
     index.insert(entry_to_document(entry))
+    index.storage_context.persist(persist_dir=_persist_dir(user_id))
+
+
+def upsert_entries(user_id: str, entries: Iterable[SymptomLog]) -> None:
+    index = build_or_load_index(user_id)
+    for e in entries:
+        index.insert(entry_to_document(e))
     index.storage_context.persist(persist_dir=_persist_dir(user_id))
 
 def query_index(user_id: str, question: str, k: int = 8):

--- a/tests/test_memory_index.py
+++ b/tests/test_memory_index.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List
+
+import importlib
+
+import pytest
+from tools.health_schema import Severity, SymptomLog
+
+
+class DummyNode:
+    def __init__(self, doc):
+        self._doc = doc
+        self.metadata = getattr(doc, "metadata", {})
+
+    def get_content(self) -> str:
+        return getattr(self._doc, "text", "")
+
+    def get_score(self) -> float:
+        return 1.0
+
+
+class DummyRetriever:
+    def __init__(self, docs: List, limit: int):
+        self._docs = docs
+        self._limit = limit
+
+    def retrieve(self, query: str):
+        query_lc = query.lower()
+        matches = [
+            DummyNode(doc)
+            for doc in self._docs
+            if query_lc in getattr(doc, "text", "").lower()
+        ]
+        return matches[: self._limit]
+
+
+class DummyStorageContext:
+    def __init__(self) -> None:
+        self.persisted_dirs: List = []
+
+    def persist(self, persist_dir):
+        self.persisted_dirs.append(persist_dir)
+
+
+class DummyIndex:
+    def __init__(self) -> None:
+        self.documents: List = []
+        self.storage_context = DummyStorageContext()
+
+    def insert(self, doc) -> None:
+        self.documents.append(doc)
+
+    def as_retriever(self, similarity_top_k: int = 8):
+        return DummyRetriever(self.documents, similarity_top_k)
+
+
+@pytest.fixture()
+def sample_entries() -> List[SymptomLog]:
+    now = datetime.now(timezone.utc)
+    return [
+        SymptomLog(
+            symptom="Fever",
+            severity=Severity.mild,
+            started_at=now,
+            notes="High fever",
+        ),
+        SymptomLog(
+            symptom="Cough",
+            severity=Severity.moderate,
+            started_at=now,
+            notes="Persistent cough",
+        ),
+    ]
+
+
+def test_upsert_entries_updates_index(monkeypatch, tmp_path, sample_entries):
+    memory_index = importlib.import_module("memory.index")
+    upsert_entries = memory_index.upsert_entries
+    query_index = memory_index.query_index
+
+    dummy_index = DummyIndex()
+
+    def fake_build_or_load_index(user_id: str):
+        return dummy_index
+
+    def fake_persist_dir(user_id: str):
+        path = tmp_path / user_id
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    monkeypatch.setattr(memory_index, "build_or_load_index", fake_build_or_load_index)
+    monkeypatch.setattr(memory_index, "_persist_dir", fake_persist_dir)
+
+    upsert_entries("u-123", sample_entries)
+
+    results = query_index("u-123", "fever")
+
+    assert any("fever" in result["text"].lower() for result in results)

--- a/tools/log_entry.py
+++ b/tools/log_entry.py
@@ -3,6 +3,7 @@ import json
 import logging
 
 from tools.health_schema import SymptomLog, Severity
+from memory.index import upsert_entries
 from db.engine import SessionLocal, Base, engine
 from db.models import SymptomLogORM
 
@@ -40,6 +41,11 @@ def tool_log(text: str, user_id: str) -> str:
             db.add(orm_entry)
             db.commit()
             db.refresh(orm_entry)
+
+            upsert_entries(
+                user_id,
+                [SymptomLog.model_validate(orm_entry, from_attributes=True)],
+            )
         except Exception as exc:
             db.rollback()
             logger.error("Failed to log symptom entry: %s", exc)


### PR DESCRIPTION
## Summary
- add an `upsert_entries` helper to refresh stored indexes for multiple entries
- call the helper after logging a symptom so the persisted index stays current
- cover the helper with a dummy index unit test and ignore the storage directory

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d73ecb35ec832f99a40c7e1435e89c