### PR TITLE
Add routing layer with heuristic and optional LlamaIndex agent

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, List
+import re
+from typing import Any, Dict, List, Optional
 
 import dateparser
 import gradio as gr
@@ -23,6 +24,205 @@ logger = logging.getLogger(__name__)
 
 # Ensure OpenAI credentials are loaded from the environment
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+
+def log_entry(user_id: str, message: str):
+    """Adapter exposing ``tool_log`` with a friendlier signature."""
+
+    return tool_log(text=message, user_id=user_id)
+
+
+def get_entries(user_id: str, since: Optional[str] = None):
+    """Adapter for ``tool_get_entries`` supporting an optional ``since`` argument."""
+
+    entries = tool_get_entries(user_id=user_id)
+    if since:
+        dt = dateparser.parse(since)
+        if dt:
+            filtered = []
+            for entry in entries:
+                started = entry.get("started_at")
+                created = entry.get("created_at")
+                ts = dateparser.parse(started) if started else None
+                if not ts and created:
+                    ts = dateparser.parse(created)
+                if ts and ts >= dt:
+                    filtered.append(entry)
+            return filtered
+    return entries
+
+
+def summarize(user_id: str, question: str | None = None, days: int = 7):
+    """Adapter for ``tool_summarize`` ignoring extra guidance parameters for now."""
+
+    _ = question, days  # kept for compatibility / future use
+    return tool_summarize(user_id=user_id)
+
+
+ROUTER_MODE = os.getenv("ROUTER_MODE", "heuristic").strip().lower()  # "heuristic" (default) or "llamaindex"
+
+SYMPTOM_HINTS = {
+    "pain",
+    "ache",
+    "numb",
+    "tingle",
+    "fever",
+    "dizzy",
+    "dizziness",
+    "nausea",
+    "vomit",
+    "cough",
+    "fatigue",
+    "headache",
+    "migraine",
+    "sore",
+    "cramp",
+    "cramping",
+}
+
+TIME_HINT_RE = re.compile(
+    r"\b(today|yesterday|this morning|last night|since|for\s+\d+\s+(day|days|week|weeks|hour|hours))\b",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_logging(text: str) -> bool:
+    """Heuristic: symptom-ish words or time anchors → likely a log request."""
+
+    t = text.lower()
+    symptomy = any(w in t for w in SYMPTOM_HINTS)
+    timey = bool(TIME_HINT_RE.search(t))
+    return symptomy or timey
+
+
+def _is_summarize_intent(text: str) -> bool:
+    return bool(re.search(r"\b(summarize|summary|trend|overview|doctor)\b", text, re.I))
+
+
+def _is_list_intent(text: str) -> bool:
+    return bool(re.search(r"\b(show|list|entries|logs?)\b", text, re.I))
+
+
+def format_confirmation(result) -> str:
+    """Turn tool results into short user-facing text."""
+
+    try:
+        main = getattr(result, "main_symptom", None) or getattr(result, "symptom", None)
+        sev = getattr(result, "severity", None)
+        ts = getattr(result, "timestamp", None)
+        meds = getattr(result, "medicines_taken", None)
+        if main or sev or ts or meds:
+            parts = []
+            if main:
+                parts.append(str(main))
+            if sev is not None:
+                parts.append(f"({sev}/10)")
+            if ts:
+                parts.append(f"since {ts}")
+            if meds:
+                parts.append(f"meds: {meds}")
+            return "Logged: " + " ".join(parts)
+        if isinstance(result, (list, tuple)):
+            return f"{len(result)} entr{'y' if len(result) == 1 else 'ies'} found."
+        return str(result)
+    except Exception:
+        return str(result)
+
+
+def heuristic_route(user_id: str, text: str):
+    """Rule-based router: slash commands > keywords > symptom heuristic > default summarize."""
+
+    msg = text.strip()
+    head = msg.split(" ", 1)[0].lower()
+
+    if head == "/log":
+        payload = msg[len("/log"):].strip() or msg
+        return format_confirmation(log_entry(user_id=user_id, message=payload))
+    if head == "/entries":
+        return format_confirmation(get_entries(user_id=user_id))
+    if head == "/sum":
+        payload = msg[len("/sum"):].strip() or "Summarize my recent symptoms."
+        return str(summarize(user_id=user_id, question=payload))
+
+    if _is_summarize_intent(msg):
+        return str(summarize(user_id=user_id, question=msg))
+    if _is_list_intent(msg):
+        return format_confirmation(get_entries(user_id=user_id))
+
+    if _looks_like_logging(msg):
+        try:
+            return format_confirmation(log_entry(user_id=user_id, message=msg))
+        except Exception as e:  # pragma: no cover - guard rails
+            logger.exception("log_entry failed; asking for fields")
+            return (
+                "I couldn't parse that. Please include: symptom, severity (0–10), "
+                "and when it started (e.g., 'Headache 6/10 since 8pm, 2h, took Advil')."
+            )
+
+    return str(summarize(user_id=user_id, question=msg))
+
+
+def llamaindex_route(user_id: str, text: str) -> str:
+    """Route via a small LlamaIndex agent. Raises on indecision so caller can fallback."""
+
+    from llama_index.core.agent import ReActAgent
+    from llama_index.core.tools import FunctionTool
+    from llama_index.llms.openai import OpenAI
+
+    def _tool(fn, name, desc):
+        return FunctionTool.from_defaults(fn=fn, name=name, description=desc)
+
+    t_log = _tool(
+        lambda user_id, message: log_entry(user_id=user_id, message=message),
+        "log_entry",
+        "Parse free-text symptom note, save to DB, and update the index.",
+    )
+    t_entries = _tool(
+        lambda user_id, since=None: get_entries(user_id=user_id, since=since),
+        "get_entries",
+        "List recent symptom logs for the user.",
+    )
+    t_sum = _tool(
+        lambda user_id, question="Summarize my recent symptoms.", days=7: summarize(
+            user_id=user_id, question=question, days=days
+        ),
+        "summarize",
+        "Concise, doctor-friendly summary grounded in recent entries.",
+    )
+
+    SYSTEM_PROMPT = (
+        "You are HealthTrack-AI. Choose exactly ONE tool that best answers the user.\n"
+        "- If the message looks like a symptom note (e.g., 'Headache 6/10 since 8pm…'), use log_entry.\n"
+        "- If they ask to see notes, use get_entries.\n"
+        "- If they ask for an overview/trends/doctor note, use summarize.\n"
+        "Be concise. Never invent data."
+    )
+
+    llm = OpenAI(model="gpt-4o-mini", temperature=0.1)
+    agent = ReActAgent.from_tools(
+        [t_log, t_entries, t_sum], system_prompt=SYSTEM_PROMPT, llm=llm, verbose=False
+    )
+
+    prompt = f"user_id={user_id}\n{text}"
+    resp = agent.chat(prompt)
+
+    s = str(resp).strip()
+    if not s or "ToolExecutionError" in s or "I cannot decide" in s:
+        raise RuntimeError("Agent indecision or failure")
+
+    return s
+
+
+def route_message(user_id: str, text: str) -> str:
+    """Main entry: try agent when enabled; otherwise or on failure, use heuristic."""
+
+    if ROUTER_MODE == "llamaindex":
+        try:
+            return llamaindex_route(user_id=user_id, text=text)
+        except Exception as e:  # pragma: no cover - guard rails
+            logger.warning("llamaindex_route failed (%s); falling back to heuristic.", e)
+            return heuristic_route(user_id=user_id, text=text)
+    return heuristic_route(user_id=user_id, text=text)
 
 
 # ---------------------------------------------------------------------------
@@ -47,7 +247,7 @@ def _serialise(entry: SymptomLog | Dict[str, Any]) -> Dict[str, Any]:
 def _log_symptom(user_id: str, text: str) -> Dict[str, Any]:
     """Persist ``text`` for ``user_id`` and return the stored entry."""
 
-    msg = tool_log(text=text, user_id=user_id)
+    msg = log_entry(user_id=user_id, message=text)
     try:
         entry_id = msg.rsplit(":", 1)[1].strip()
     except Exception as exc:  # pragma: no cover - defensive
@@ -62,7 +262,7 @@ def _log_symptom(user_id: str, text: str) -> Dict[str, Any]:
 def _list_entries(user_id: str, since: str | None = None) -> List[Dict[str, Any]]:
     """Return all entries for ``user_id`` optionally filtered by ``since``."""
 
-    entries = [_serialise(e) for e in tool_get_entries(user_id)]
+    entries = [_serialise(e) for e in get_entries(user_id=user_id)]
 
     if since:
         dt = dateparser.parse(since)
@@ -126,7 +326,7 @@ def api_summary(user_id: str = Query(..., description="User identifier")):
     """Return a doctor-friendly summary of recent entries."""
 
     try:
-        return {"summary": tool_summarize(user_id)}
+        return {"summary": summarize(user_id=user_id)}
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception("Summary endpoint failed")
         raise HTTPException(status_code=500, detail="Internal Server Error") from exc
@@ -155,19 +355,13 @@ fastapi_app.add_middleware(
 
 with gr.Blocks() as demo:
     user_box = gr.Textbox(label="User ID")
-    symptom_box = gr.Textbox(label="Symptom description", lines=2)
-    log_btn = gr.Button("Log")
-    log_output = gr.JSON(label="Saved entry")
+    message_box = gr.Textbox(label="Message", lines=3)
+    gr.Markdown("Tip: /log …, /entries, /sum …")
+    send_btn = gr.Button("Send")
+    response_box = gr.Markdown(label="Response")
 
-    view_btn = gr.Button("View entries")
-    entries_output = gr.Dataframe(label="Entries")
-
-    summary_btn = gr.Button("Summarize for doctor")
-    summary_output = gr.Markdown()
-
-    log_btn.click(_log_symptom, inputs=[user_box, symptom_box], outputs=log_output)
-    view_btn.click(_list_entries, inputs=[user_box], outputs=entries_output)
-    summary_btn.click(tool_summarize, inputs=[user_box], outputs=summary_output)
+    send_btn.click(route_message, inputs=[user_box, message_box], outputs=response_box)
+    message_box.submit(route_message, inputs=[user_box, message_box], outputs=response_box)
 
 
 # Mount Gradio UI at `/` and expose FastAPI under `/api`.


### PR DESCRIPTION
## Summary
- add heuristic and optional LlamaIndex agent routers that unify tool usage through `route_message`
- provide formatting helpers and adapters so existing tools work with routing layer
- update Gradio UI to use the new router and guide users with slash-command hints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8198c2d10832f82888fa91dd0955a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Unified chat-style interface with a single message box and Send button.
  - Optional agent-driven routing alongside heuristic routing for smarter intent handling.
  - Slash-command support for logging, listing, and summarization.

- Enhancements
  - Adapter-style API surface for logging, retrieval, and summarization to simplify integrations.
  - Improved input parsing with symptom hints, time anchors, and timezone-aware date handling.
  - Clearer, structured confirmation responses and graceful fallback when advanced routing fails.

- Bug Fixes
  - More robust error handling and preserved API compatibility during internal changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->